### PR TITLE
Fix Directory Name in Documentation

### DIFF
--- a/MyDU server modding toolkit.md
+++ b/MyDU server modding toolkit.md
@@ -14,7 +14,7 @@ They have the capability to inject contextual entries to the client’s popup me
 
 ## Getting started
 
-Download the mod toolkit archive and run “dotnet build” in the “ModAdmin” directory which contains a sample mod.
+Download the mod toolkit archive and run “dotnet build” in the “SampleDllMod” directory which contains a sample mod.
 
 Copy the generated ModAdmin.dll in the Mods directory at the root of the mydu server install directory.
 


### PR DESCRIPTION
### **Description:**
This PR updates the MyDU server modding toolkit.md file to ensure the referenced directory name correctly matches the actual directory rather than the project file. This improves clarity and reduces confusion for users following the instructions.

### **Changes:**
- Modified the directory name "ModAdmin", in "MyDU server modding toolkit.md", to "SampleDllMod" in order reflect the correct directory name.

### **Why this change?**
- The previous directory name matched the project file (ModAdmin.csproj) instead of the actual directory (SampleDllMod).
- This correction ensures users can accurately follow the toolkit example without errors.

### **Testing:**
- Reviewed the documentation to confirm the directory name now aligns with the correct structure.
